### PR TITLE
Add interactive drawing tools

### DIFF
--- a/templating/__init__.py
+++ b/templating/__init__.py
@@ -1,8 +1,8 @@
-from .dsl import Line, Spline, Arc, Segment, Feature, parse
+from .dsl import Line, Spline, Arc, Segment, Feature, parse, serialize
 
 try:
     from .renderer import Renderer
 except Exception:  # pragma: no cover - optional dependency
     Renderer = None
 
-__all__ = ["Line", "Spline", "Arc", "Segment", "Feature", "parse", "Renderer"]
+__all__ = ["Line", "Spline", "Arc", "Segment", "Feature", "parse", "serialize", "Renderer"]

--- a/templating/dsl.py
+++ b/templating/dsl.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Iterable
 
 @dataclass
 class Line:
@@ -70,4 +70,23 @@ def parse(text: str) -> List[Feature]:
         features.append(Feature(start, segments))
         i += 1
     return features
+
+
+def serialize(features: Iterable[Feature]) -> str:
+    """Serialize a list of features back into the template DSL."""
+    lines: List[str] = []
+    for feature in features:
+        lines.append(f"FEATURE {feature.start[0]} {feature.start[1]}")
+        for seg in feature.segments:
+            if isinstance(seg, Line):
+                lines.append(f"LINE {seg.x} {seg.y}")
+            elif isinstance(seg, Spline):
+                coord_parts = " ".join(f"{x} {y}" for x, y in seg.points)
+                lines.append(f"SPLINE {coord_parts}")
+            elif isinstance(seg, Arc):
+                lines.append(
+                    f"ARC {seg.cx} {seg.cy} {seg.radius} {seg.start_angle} {seg.end_angle}"
+                )
+        lines.append("END")
+    return "\n".join(lines)
 

--- a/templating/gui.py
+++ b/templating/gui.py
@@ -1,18 +1,28 @@
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Optional, Sequence, List, Tuple
 
 import numpy as np
-from PySide6 import QtWidgets, QtGui
+from PySide6 import QtWidgets, QtGui, QtCore
 
-from .dsl import Arc, Feature, Line, Spline, parse
+from .dsl import Arc, Feature, Line, Spline, parse, serialize
 from .renderer import Renderer
 
 
 class Canvas(QtWidgets.QLabel):
-    def __init__(self, width: int = 400, height: int = 400, parent: Optional[QtWidgets.QWidget] = None) -> None:
+    def __init__(
+        self,
+        width: int = 400,
+        height: int = 400,
+        parent: Optional[QtWidgets.QWidget] = None,
+        on_change=None,
+    ) -> None:
         super().__init__(parent)
         self.renderer = Renderer(width, height)
         self.setFixedSize(width, height)
         self.update_pixmap()
+        self.features: List[Feature] = []
+        self.draw_mode: Optional[str] = None
+        self.temp_points: List[Tuple[float, float]] = []
+        self.on_change = on_change
 
     def _numpy_to_qimage(self, arr: np.ndarray) -> QtGui.QImage:
         height, width, _ = arr.shape
@@ -28,24 +38,84 @@ class Canvas(QtWidgets.QLabel):
         self.renderer.draw_features(features)
         self.update_pixmap()
 
+    def set_mode(self, mode: Optional[str]) -> None:
+        self.draw_mode = mode
+        self.temp_points.clear()
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
+        if not self.draw_mode:
+            return
+        pos = (event.position().x(), event.position().y())
+        self.temp_points.append(pos)
+        if self.draw_mode == "line" and len(self.temp_points) == 2:
+            start, end = self.temp_points
+            feat = Feature(start, [Line(end[0], end[1])])
+            self.features.append(feat)
+            self.draw_features(self.features)
+            self.temp_points.clear()
+            if self.on_change:
+                self.on_change(self.features)
+        elif self.draw_mode == "arc" and len(self.temp_points) == 3:
+            center, start_pt, end_pt = self.temp_points
+            from math import atan2, degrees, hypot
+
+            radius = hypot(start_pt[0] - center[0], start_pt[1] - center[1])
+            start_a = degrees(atan2(start_pt[1] - center[1], start_pt[0] - center[0]))
+            end_a = degrees(atan2(end_pt[1] - center[1], end_pt[0] - center[0]))
+            feat = Feature(start_pt, [Arc(center[0], center[1], radius, start_a, end_a)])
+            self.features.append(feat)
+            self.draw_features(self.features)
+            self.temp_points.clear()
+            if self.on_change:
+                self.on_change(self.features)
+        elif self.draw_mode == "spline":
+            # points are collected until a double click finishes the spline
+            pass
+
+    def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent) -> None:
+        if self.draw_mode == "spline":
+            pos = (event.position().x(), event.position().y())
+            self.temp_points.append(pos)
+            if len(self.temp_points) >= 3:
+                start = self.temp_points[0]
+                pts = self.temp_points[1:]
+                feat = Feature(start, [Spline(pts)])
+                self.features.append(feat)
+                self.draw_features(self.features)
+                if self.on_change:
+                    self.on_change(self.features)
+            self.temp_points.clear()
+
 
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Template Editor")
         self.text = QtWidgets.QPlainTextEdit()
-        self.canvas = Canvas()
+        self.canvas = Canvas(on_change=self._on_canvas_change)
 
         save_png = QtWidgets.QPushButton("Save PNG")
         save_svg = QtWidgets.QPushButton("Save SVG")
         redraw = QtWidgets.QPushButton("Redraw")
+        line_btn = QtWidgets.QPushButton("Line")
+        arc_btn = QtWidgets.QPushButton("Arc")
+        spline_btn = QtWidgets.QPushButton("Spline")
+        clear_btn = QtWidgets.QPushButton("Clear")
 
         save_png.clicked.connect(self.export_png)
         save_svg.clicked.connect(self.export_svg)
         redraw.clicked.connect(self.update_view)
+        line_btn.clicked.connect(lambda: self.canvas.set_mode("line"))
+        arc_btn.clicked.connect(lambda: self.canvas.set_mode("arc"))
+        spline_btn.clicked.connect(lambda: self.canvas.set_mode("spline"))
+        clear_btn.clicked.connect(self._clear_canvas)
 
         button_layout = QtWidgets.QHBoxLayout()
         button_layout.addWidget(redraw)
+        button_layout.addWidget(line_btn)
+        button_layout.addWidget(arc_btn)
+        button_layout.addWidget(spline_btn)
+        button_layout.addWidget(clear_btn)
         button_layout.addWidget(save_png)
         button_layout.addWidget(save_svg)
 
@@ -57,6 +127,14 @@ class MainWindow(QtWidgets.QMainWindow):
         central = QtWidgets.QWidget()
         central.setLayout(layout)
         self.setCentralWidget(central)
+
+    def _on_canvas_change(self, features: Sequence[Feature]) -> None:
+        self.text.setPlainText(serialize(features))
+
+    def _clear_canvas(self) -> None:
+        self.canvas.features = []
+        self.canvas.draw_features([])
+        self.text.clear()
 
     def update_view(self) -> None:
         text = self.text.toPlainText()

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,5 +1,5 @@
 import unittest
-from templating.dsl import parse, Line, Spline, Arc, Feature
+from templating.dsl import parse, serialize, Line, Spline, Arc, Feature
 
 class TestDSL(unittest.TestCase):
     def test_parse(self):
@@ -21,6 +21,17 @@ class TestDSL(unittest.TestCase):
             features[1].segments[1],
             Spline([(0.0, 0.0), (1.0, 1.0), (2.0, 0.0)]),
         )
+
+    def test_serialize_roundtrip(self):
+        text = (
+            "FEATURE 0 0\n"
+            "LINE 10 0\n"
+            "LINE 10 10\n"
+            "END\n"
+        )
+        features = parse(text)
+        out = serialize(features)
+        self.assertEqual(parse(out), features)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `serialize` helper to convert features back to DSL
- expose `serialize` from package
- implement interactive drawing modes (line, arc, spline) in GUI
- allow clearing canvas and show drawn DSL in text field
- add `serialize` roundtrip unit test

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684f65fa93788326a171146db9152944